### PR TITLE
added image padding fix

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -43,3 +43,11 @@ tr.even, tr.odd { background: none; border-bottom: 1px solid #eee; }
   width: 100%;
   left: 0;
 }
+
+.pane-content figure.image.float-left {
+  padding-right: 1rem;
+}
+
+.pane-content figure.image.float-right {
+  padding-left: 1rem;
+}


### PR DESCRIPTION
I got an RT ticket about image padding when its left aligned. It was closed, but this is a global fix for such issues.

Example page where I tested changes: https://www.ebi.ac.uk/about/news/feature-story/open-data-latin-america